### PR TITLE
upgrade actions to node v20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
+          node-version: '20'
           cache: 'yarn'
       - run: yarn install
 
@@ -27,6 +28,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
+          node-version: '20'
           cache: 'yarn'
       - run: yarn install
       - name: Run Build
@@ -40,6 +42,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
+          node-version: '20'
           cache: 'yarn'
       - run: yarn install
       - name: Run Lint
@@ -53,6 +56,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
+          node-version: '20'
           cache: 'yarn'
       - run: yarn install
       - name: Run Format
@@ -66,6 +70,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
+          node-version: '20'
           cache: 'yarn'
       - run: yarn install
       - name: Run Typecheck
@@ -79,6 +84,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
+          node-version: '20'
           cache: 'yarn'
       - run: yarn install
       - name: Run Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,10 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
           cache: 'yarn'
       - run: yarn install
 
@@ -24,11 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
           cache: 'yarn'
       - run: yarn install
       - name: Run Build
@@ -38,11 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
           cache: 'yarn'
       - run: yarn install
       - name: Run Lint
@@ -52,11 +49,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
           cache: 'yarn'
       - run: yarn install
       - name: Run Format
@@ -66,11 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
           cache: 'yarn'
       - run: yarn install
       - name: Run Typecheck
@@ -80,11 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
           cache: 'yarn'
       - run: yarn install
       - name: Run Tests


### PR DESCRIPTION
### Problem
We are getting some warnings when running actions related to node version. We should move to v20.
![image](https://github.com/cabify/javascript-actions/assets/12680376/aa767fba-d070-45d0-ab2e-2fe0c7db4944)

### Solution
Upgrade node version to v20 in jobs